### PR TITLE
Salesforce component tweaks

### DIFF
--- a/salesforce-subtheme/salesforce-subtheme.css
+++ b/salesforce-subtheme/salesforce-subtheme.css
@@ -19,6 +19,13 @@
   font-weight: bold;
 }
 
+.salesforce-box p {
+  margin-bottom: 0 none;
+  font-size: 1em!important;
+  padding-left: 3px;
+}
+
+
 .clickpath {
   background-color: var(--lightyellow);
 }

--- a/salesforce-subtheme/salesforce-subtheme.css
+++ b/salesforce-subtheme/salesforce-subtheme.css
@@ -26,38 +26,38 @@
 }
 
 
-.clickpath {
+.sf-clickpath {
   background-color: var(--lightyellow);
 }
 
-.clickpath::before {
+.sf-clickpath::before {
   content: "CLICK PATH";
   background-image: url('mousepointer.svg');
 }
 
-.note {
+.sf-note {
   background-color: var(--lightgreen);
 }
 
-.note::before {
+.sf-note::before {
   content: "NOTE";
   background-image: url('notebook.svg');
 }
 
-.alert {
+.sf-alert {
   background-color: var(--lightblue);
 }
 
-.alert::before {
+.sf-alert::before {
   content: "ALERT";
   background-image: url('exclamationmark.svg');
 }
 
-.definition {
+.sf-definition {
   background-color: var(--lightpurple);
 }
 
-.definition::before {
+.sf-definition::before {
   content: "DEFINITION";
   background-image: url('questionmark.svg');
 }


### PR DESCRIPTION
Minor tweaks for the Salesforce components. Removes margin on `<p>` tags in side of these boxes and makes the text slightly smaller, as well as adding a few pixels padding on the left to align it with the edge of the icon.

Note that the classes have been updated with a `sf-` namespace.

